### PR TITLE
added build-deploy because deploy fails silently on ".dist/" not being found

### DIFF
--- a/index.js
+++ b/index.js
@@ -360,6 +360,15 @@ module.exports = function (gulp) {
     );
   });
 
+  //gulp deploy fails silently (oh javascript) if .dist/ is not not already built... 
+  gulp.task('build-deploy', function (cb) {
+    return sequence(
+      'build-clean',
+      ['build-copy-config', 'build-copy-partials', 'build-copy-fonts', 'build-min', 'build-images'],
+      'deploy'
+    );
+  });
+
   gulp.task('export', function (cb) {
     sequence(
       'build-clean',


### PR DESCRIPTION
Erin asked me to lend a hand and figure out why `gulp deploy` worked for you and no one else -- they were having trouble getting it to work. This is part one of a two part commit. The second part is for gulp-subtree.

I tried adding in an error catch for 'gulp deploy' but JavaScript is really not my language and anything I'd do would just be a hack.

Signed-off-by: buckie wjmartino@gmail.com
