### PR TITLE
remove execsync as dependency and use native calls for node 0.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var fs = require('fs-extra'),
     shell = require('gulp-shell'),
     browserSync = require('browser-sync'),
     reload = browserSync.reload,
-    execSync = require('execSync'),
+    execute = require('child_process').exec,
     sequence = require('run-sequence'),
     yaml = require('yamljs'),
     usemin = require('gulp-usemin'),
@@ -185,7 +185,7 @@ module.exports = function (gulp) {
     fs.copySync('index.html', sp__paths.server + '/index.html');
 
     // Compile Sasss
-    compass = execSync.exec('bundle exec compass compile --force --time --css-dir=.www/' + dirs.css);
+    compass = execute('bundle exec compass compile --force --time --css-dir=.www/' + dirs.css);
     gutil.log(compass.stdout);
 
     cb();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "browser-sync": "^1.3.3",
     "compass-options": "^0.1.1",
     "event-stream": "^3.1.7",
-    "execSync": "^1.0.1-pre",
     "fs-extra": "^0.10.0",
     "gulp-cached": "^1.0.1",
     "gulp-imagemin": "^0.6.2",


### PR DESCRIPTION
This was depreciated too.

Made updates. Hopefully you can merge these soon so we don't have problems in the future.
